### PR TITLE
Allow 2xx status codes in RequestBuilder

### DIFF
--- a/Sources/API/RequestBuilder.swift
+++ b/Sources/API/RequestBuilder.swift
@@ -53,7 +53,8 @@ public class RequestBuilder {
             let response = APIResponse(body: data, response: urlResponse)
 
             logging(.info, "\(url), response(\(response.statusCode?.description ?? "nil")), \(round(start.elapsedTime * 1000) / 1000) s, \(response.body.count) bytes")
-            guard response.statusCode == 200 else {
+            guard let statusCode = response.statusCode,
+                  (200...299).contains(statusCode) else {
                 throw Error.badResponse(response)
             }
 


### PR DESCRIPTION
## Summary
- relax success status code check to allow any 2xx response

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6862307450a88331928e655a02a15be7